### PR TITLE
bug: Fix Github templates issues and add missing label to the drafter

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Steps to check when is complete
 
-[] The issue was documented when resolved
-[] All things related to the issue had it correct labels
-[] The project, PR, and milestone were added to this issue
-[] If a PR was needed; it was merged into the main branch
+* [ ] The issue was documented when resolved
+* [ ] All things related to the issue had it correct labels
+* [ ] The project, PR, and milestone were added to this issue
+* [ ] If a PR was needed; it was merged into the main branch

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 # Pull Request Objective
 
 <!-- Provide an overall description of the PR -->
+
 ## Issue
 
 <!-- Change the number at the end of the URL with your issue number -->

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,6 +12,10 @@ categories:
       - 'bug'
   - title: '🧰 Maintenance'
     label: 'chore'
+  - title: '📄 Documentation'
+    labels:
+      - 'documentation'
+      - 'docs'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
 version-resolver:


### PR DESCRIPTION
# Pull Request Objective

<!-- Provide an overall description of the PR -->

## Issue

<!-- Change the number at the end of the URL with your issue number -->
N/A

## List of changes

<!-- Provide a list of the changes added to this PR -->
- Add space on `Pull Request` template
- Fix the `checkboxes` on the `Issue` template
- Add the `docs` labels to the `release drafter`

## Notes

<!-- Add relevant notes -->
